### PR TITLE
fix(gui): Ripristina il focus dopo l'apertura del menu a tendina

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -469,6 +469,8 @@ class BreedingToolApp(tk.Tk):
 
         # Mostra la lista aggiornata
         widget.event_generate('<Down>')
+        # Forza il focus a tornare sul widget di input
+        widget.focus_set()
 
     def _perform_autocomplete(self, widget):
         """Esegue l'autocompletamento del testo e aggiorna la lista."""
@@ -495,6 +497,8 @@ class BreedingToolApp(tk.Tk):
 
             # Apre il menu a tendina per mostrare i suggerimenti
             widget.event_generate('<Down>')
+            # Forza il focus a tornare sul widget di input
+            widget.focus_set()
         else:
             # Nessuna corrispondenza, resetta la lista
             widget['values'] = self.pokemon_names


### PR DESCRIPTION
Risolve un problema di usabilità per cui il menu a tendina dell'autocompletamento "rubava" il focus dal campo di testo, impedendo all'utente di continuare a digitare.

- Aggiunge una chiamata a `widget.focus_set()` dopo aver generato l'evento di apertura del menu a tendina.
- Questo viene fatto sia per il completamento del testo (`_perform_autocomplete`) sia per il filtraggio della lista (`_filter_list`).
- Il risultato è un'esperienza di digitazione fluida e ininterrotta, come previsto dall'utente.